### PR TITLE
fix: resolve Keg build issues with lisp/ directory structure

### DIFF
--- a/Keg
+++ b/Keg
@@ -9,9 +9,6 @@
 ;; Package file
 (package-file "lisp/bfepm.el")
 
-;; Source files
-(files "lisp/*.el" "lisp/*.el.in")
-
 ;; Runtime dependencies
 (depends-on "emacs" "29.1")
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ install:
 
 # Build the project
 build: install
-	$(KEG) build
+	$(EMACS) -batch -L lisp \
+		--eval "(setq byte-compile-error-on-warn t)" \
+		-f batch-byte-compile lisp/*.el
 
 # Run tests with ERT
 test: build


### PR DESCRIPTION
## Summary
- Fix critical build system issues with Keg configuration for lisp/ directory structure
- Update Makefile to use direct emacs compilation ensuring reliable builds and tests

## Test plan
- [x] `make build` completes successfully
- [x] `make test` runs all 31 tests and passes
- [x] `make check` runs compilation, linting, and tests successfully  
- [x] `make clean && make build && make test` works for clean builds
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to byte-compile Emacs Lisp files directly using Emacs, instead of relying on the previous tool.
  - Removed the "Source files" section from the package definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->